### PR TITLE
Update QEMU version to 2.12 from Debian Buster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   --keyring=/usr/share/keyrings/$OS-archive-keyring.gpg
   --arch=$ARCH
   --variant=minbase
+  --include=ascii
   $DIST
   $MIRROR
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ install:
 - sudo apt-get update -y && sudo apt-get install -y debootstrap dpkg
 - wget http://mirrors.kernel.org/ubuntu/pool/universe/d/debian-archive-keyring/debian-archive-keyring_2017.6_all.deb &&
   sudo dpkg -i debian-archive-keyring_2017.6_all.deb
-- wget http://mirrors.kernel.org/ubuntu/pool/universe/q/qemu/qemu-user-static_2.10+dfsg-0ubuntu3_amd64.deb &&
-  sudo dpkg -i qemu-user-static_2.10+dfsg-0ubuntu3_amd64.deb
+- sudo apt install qemu-user-static &&
+  wget http://deb.debian.org/debian/pool/main/q/qemu/qemu-user-static_2.12+dfsg-3+b1_amd64.deb &&
+  sudo dpkg-deb -x qemu-user-static_2.12+dfsg-3+b1_amd64.deb / &&
+  echo "QEMU updated successfully!"
 - if [ "$OS" == "raspbian" ]; then
    wget http://archive.raspbian.org/raspbian/pool/main/r/raspbian-archive-keyring/raspbian-archive-keyring_20120528.2_all.deb &&
    sudo dpkg -i raspbian-archive-keyring_20120528.2_all.deb &&


### PR DESCRIPTION
Hi,

This is my proposal to unblock https://github.com/ev3dev/docker-library/pull/4 . I have picked a newer QEMU version from here: https://packages.debian.org/buster/qemu-user-static . I have tested the executable on Debian Stretch amd64 chroot and it runs Java fine.

Thanks,
Jakub